### PR TITLE
Fixed List crash by disabling detailItem code in ListTableVC

### DIFF
--- a/RouteTracker/AppDelegate.m
+++ b/RouteTracker/AppDelegate.m
@@ -35,7 +35,7 @@
         [[NSUserDefaults standardUserDefaults] setObject:@"EdibleMontereyDistributionList" forKey:@"selected_spreadsheet"];
         [[NSUserDefaults standardUserDefaults] setInteger:0 forKey:@"selected_map_type"];
         [[NSUserDefaults standardUserDefaults] setObject:@"ALL" forKey:@"selected_driver"];
-        [[NSUserDefaults standardUserDefaults] setObject:@"initialString" forKey:@"selected_plist"];
+   //     [[NSUserDefaults standardUserDefaults] setObject:@"initialString" forKey:@"selected_plist"];
         [[NSUserDefaults standardUserDefaults] setObject:@"initialDictionary" forKey:@"selected_member"];
         [[NSUserDefaults standardUserDefaults] setObject:@"selectedIndexPath" forKey:@"selected_indexPath"];
         

--- a/RouteTracker/ListTableViewController.m
+++ b/RouteTracker/ListTableViewController.m
@@ -69,22 +69,22 @@
         [self makeIndexedArray:delegate.memberData.membersArray withIndex:self.indexArray];
     }
     
-// Saves the edited member (detailItem) to the current array
-    NSDictionary *editedMemberItem = [[NSUserDefaults standardUserDefaults] objectForKey:@"selected_member"];
-    NSLog(@"edited member = %@", editedMemberItem);
-    NSArray *selectedIndexPathArray = [[NSUserDefaults standardUserDefaults] objectForKey:@"selected_indexPath"];
-    NSLog(@"It's indexPath = %@", selectedIndexPathArray);
-    
-// Writes edited detailItem to the filtered Array
-    NSMutableArray *theArray = [self.namesArray objectAtIndex:0];
-
-    long section = [[selectedIndexPathArray objectAtIndex:1] integerValue];
-    long row = [[selectedIndexPathArray objectAtIndex:0] integerValue];
-    NSMutableArray *theSection = [self.namesArray objectAtIndex:section];
-    NSDictionary *theDictionary = [theSection objectAtIndex:row];
-    [theSection replaceObjectAtIndex:[[selectedIndexPathArray objectAtIndex:0] integerValue] withObject:editedMemberItem];
-
-    NSLog(@"ListTableVC - the dictionary = %@", theSection);
+//// Saves the edited member (detailItem) to the current array
+//    NSDictionary *editedMemberItem = [[NSUserDefaults standardUserDefaults] objectForKey:@"selected_member"];
+//    NSLog(@"edited member = %@", editedMemberItem);
+//    NSArray *selectedIndexPathArray = [[NSUserDefaults standardUserDefaults] objectForKey:@"selected_indexPath"];
+//    NSLog(@"It's indexPath = %@", selectedIndexPathArray);
+//    
+//// Writes edited detailItem to the filtered Array
+//    NSMutableArray *theArray = [self.namesArray objectAtIndex:0];
+//
+//    long section = [[selectedIndexPathArray objectAtIndex:1] integerValue];
+//    long row = [[selectedIndexPathArray objectAtIndex:0] integerValue];
+//    NSMutableArray *theSection = [self.namesArray objectAtIndex:section];
+//    NSDictionary *theDictionary = [theSection objectAtIndex:row];
+//    [theSection replaceObjectAtIndex:[[selectedIndexPathArray objectAtIndex:0] integerValue] withObject:editedMemberItem];
+//
+//    NSLog(@"ListTableVC - the dictionary = %@", theSection);
     
 //    sortedByDriver = NO;
     memberTableViewCell = [[MemberTableViewCell alloc] init];

--- a/RouteTracker/MemberListData.m
+++ b/RouteTracker/MemberListData.m
@@ -25,25 +25,25 @@
 - (void)loadPlistData {
     NSLog(@"Loads the Plist into member array either from the main bundle (read only) or from the documents directory files downloaded from Google sheets");
     
-//    [self loadFileFromDocuments];
+    [self loadFileFromDocuments];
     
-// Loads file locally from either sheet
-    NSBundle *mainBundle = [NSBundle mainBundle];
-    NSURL *fileURL = [[NSURL alloc] init];
-    
-// Use NSUserDefault to determine which file to load
-    NSString *dataFilename = [[NSUserDefaults standardUserDefaults] stringForKey:@"selected_spreadsheet"];
-
-// Alloc/init the fileURL outside the boundaries of switch/case statement
-        fileURL = [mainBundle URLForResource:dataFilename withExtension:@"plist"];
-
-    NSLog(@"MemberListData -loadPlistData -- fileURL = %@", fileURL);
-    
-// The secret JUICE - loads the membersArray from the file
-    self.membersArray = [NSArray arrayWithContentsOfURL:fileURL];
-
-    NSLog(@"MemberListData -loadPlistData -- self.membersArray = \n%@", self.membersArray);
-    NSLog(@"MEMBERLISTDATA Array count %d", [self.membersArray count]);
+//// Loads file locally from either sheet
+//    NSBundle *mainBundle = [NSBundle mainBundle];
+//    NSURL *fileURL = [[NSURL alloc] init];
+//    
+//// Use NSUserDefault to determine which file to load
+//    NSString *dataFilename = [[NSUserDefaults standardUserDefaults] stringForKey:@"selected_spreadsheet"];
+//
+//// Alloc/init the fileURL outside the boundaries of switch/case statement
+//        fileURL = [mainBundle URLForResource:dataFilename withExtension:@"plist"];
+//
+//    NSLog(@"MemberListData -loadPlistData -- fileURL = %@", fileURL);
+//    
+//// The secret JUICE - loads the membersArray from the file
+//    self.membersArray = [NSArray arrayWithContentsOfURL:fileURL];
+//
+////    NSLog(@"MemberListData -loadPlistData -- self.membersArray = \n%@", self.membersArray);
+//    NSLog(@"MEMBERLISTDATA Array count %d", [self.membersArray count]);
 
 // Copy members array into the names array which can later be sorted for other views
     self.namesArray = [NSArray arrayWithArray:self.membersArray];
@@ -64,14 +64,17 @@
     path = [paths objectAtIndex:0];
     path = [path stringByAppendingPathComponent:selectedFile];
 
-    // Get the data from the documents directory
+// Get the data from the documents directory
     NSData *fileData;
     fileData = [[NSFileManager defaultManager] contentsAtPath:path];
     NSString *fileDataString = [[NSString alloc] initWithData:fileData encoding:NSUTF8StringEncoding];
     
+// Parse the csv string file to a plist
+    self.membersArray = [self csvDataToArrayOfDictionaries:fileDataString];
+    
 // Perform the conversion fileURL to array
 //    NSURL *fileURL = [[NSURL alloc]initWithString:path];
-    self.membersArray = [NSMutableArray arrayWithContentsOfFile:fileDataString];
+//    self.membersArray = [NSMutableArray arrayWithContentsOfFile:fileDataString];
     NSLog(@"The membersArray = %@", self.membersArray);
 }
 

--- a/RouteTracker/SetupTableViewController.m
+++ b/RouteTracker/SetupTableViewController.m
@@ -100,7 +100,7 @@ int filesCount = 1;
     NSData *theData;
     theData = [[NSFileManager defaultManager] contentsAtPath:path];
     NSString *theDataString = [[NSString alloc] initWithData:theData encoding:NSUTF8StringEncoding];
-    NSLog(@"TheData = %@", theDataString);
+//    NSLog(@"TheData = %@", theDataString);
     
 // Now goes to the Data model MemberListData and does the actual plist to array conversion
     AppDelegate *delegate = [UIApplication sharedApplication].delegate;


### PR DESCRIPTION
The code for editng member detail data was causing membersArray not to load, therefore I commented out that code
